### PR TITLE
Changing properties used on `this` in helpers

### DIFF
--- a/index.js
+++ b/index.js
@@ -983,7 +983,7 @@ Template.prototype.defaultHelper = function(subtype, plural) {
       return '';
     }
 
-    var locs = extend({}, this.context, locals);
+    var locs = extend({}, this.ctx, locals);
 
     var content = self.renderTemplate(partial, locs);
     if (content instanceof Error) {
@@ -1026,7 +1026,7 @@ Template.prototype.defaultAsyncHelper = function(subtype, plural) {
       return next(null, '');
     }
 
-    var locs = extend({}, this.context, locals);
+    var locs = extend({}, this.ctx, locals);
     var render = self.renderSubtype(subtype);
 
     render(key, locs, function (err, content) {
@@ -1894,8 +1894,8 @@ Template.prototype.bindHelpers = function (locals, async) {
   }
 
   var o = {};
-  o.context = locals;
-  o.root = this;
+  o.ctx = locals;
+  o.app = this;
 
   locals.helpers = utils.bindAll(helpers, o);
 };


### PR DESCRIPTION
Changing `this.root` to `this.app`
Changing `this.context` to `this.ctx`
These changes only affect helpers that used `this.root` or `this.context`.

@jonschlinkert doing a PR for this since there are some helpers in `verb` and `assemble` that need to be updated. Also, the new [`helper-license`](https://github.com/helpers/helper-license/blob/master/index.js#L24) will need to be updated.
